### PR TITLE
fix(release.config.js): Update repository URL in release config

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -45,7 +45,7 @@ const config = {
 			},
 		],
 	],
-	repositoryUrl: "https://github.com/ElsiKora/ESLint-Config",
+	repositoryUrl: "https://github.com/ElsiKora/Setup-Wizard",
 };
 
 const isPrereleaseBranch = config.branches.some((b) => typeof b === "object" && branch.includes(b.name) && b.prerelease);


### PR DESCRIPTION
Updated the `repositoryUrl` in `release.config.js` to point to `https://github.com/ElsiKora/Setup-Wizard` instead of the previous `ESLint-Config` URL. This ensures the release process targets the correct repository.