### PR TITLE
ci(ci): Simplify release commit message formatting

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -55,7 +55,7 @@ if (isPrereleaseBranch) {
 		"@semantic-release/git",
 		{
 			assets: ["package.json"],
-			message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+			message: "chore(release): ${nextRelease.version} [skip ci]",
 		},
 	]);
 } else {
@@ -70,7 +70,7 @@ if (isPrereleaseBranch) {
 			"@semantic-release/git",
 			{
 				assets: ["package.json", "CHANGELOG.md"],
-				message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+				message: "chore(release): ${nextRelease.version} [skip ci]",
 			},
 		],
 	);


### PR DESCRIPTION
Removed the inclusion of release notes from the Git commit message template. This ensures a cleaner and more concise commit message for releases.