### PR TITLE
ci(ci): refactor CI setup and add major release rule

### DIFF
--- a/.elsikora/setup-wizard.config.js
+++ b/.elsikora/setup-wizard.config.js
@@ -2,14 +2,8 @@ export default {
 	ci: {
 		isEnabled: true,
 		isNpmPackage: true,
-		moduleProperties: {
-			"release-npm": {
-				isPrerelease: true,
-				mainBranch: "main",
-				preReleaseBranch: "dev",
-			},
-		},
-		modules: ["release-npm"],
+		moduleProperties: {},
+		modules: ["codecommit-sync"],
 		provider: "GitHub",
 	},
 	commitlint: {

--- a/.github/workflows/mirror-to-codecommit.yml
+++ b/.github/workflows/mirror-to-codecommit.yml
@@ -1,14 +1,13 @@
-name: Qodana Quality Scan
+name: Mirror to CodeCommit
 
 env:
-  NODE_VERSION: 20
   CHECKOUT_DEPTH: 0
 
 on: push
 
 jobs:
-  qodana_quality_scan:
-    name: Qodana Quality Scan
+  mirror_to_codecommit:
+    name: Mirror to CodeCommit
     runs-on: ubuntu-latest
 
     steps:
@@ -17,18 +16,9 @@ jobs:
         with:
           fetch-depth: ${{ env.CHECKOUT_DEPTH }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Mirror to CodeCommit
+        uses: pixta-dev/repository-mirroring-action@v1
         with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install Dependencies
-        run: npm install
-
-      - name: Build
-        run: npm run build
-
-      - name: Qodana Scan
-        uses: JetBrains/qodana-action@v2024.3
-        env:
-          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+          target_repo_url: ${{ secrets.CODECOMMIT_SSH_REPOSITORY_URL }}
+          ssh_private_key: ${{ secrets.CODECOMMIT_SSH_PRIVATE_KEY }}
+          ssh_username: ${{ secrets.CODECOMMIT_SSH_PRIVATE_KEY_ID }}

--- a/release.config.js
+++ b/release.config.js
@@ -21,6 +21,7 @@ const config = {
 				},
 				preset: "conventionalcommits",
 				releaseRules: [
+					{ breaking: true, release: "major" },
 					{ release: "minor", type: "feat" },
 					{ release: "patch", type: "fix" },
 					{ release: "patch", type: "docs" },

--- a/src/application/constant/semantic-release-config.constant.ts
+++ b/src/application/constant/semantic-release-config.constant.ts
@@ -56,6 +56,7 @@ const config = {
 				},
 				preset: "conventionalcommits",
 				releaseRules: [
+					{ breaking: true, release: "major" },
 					{ release: "minor", type: "feat" },
 					{ release: "patch", type: "fix" },
 					{ release: "patch", type: "docs" },


### PR DESCRIPTION
replaces `release-npm` with `codecommit-sync` in CI settings and updates relevant GitHub actions to mirror to CodeCommit. Adds a release rule for breaking changes to trigger a major version bump in semantic release configuration. Simplifies and aligns workflows for better maintainability.

BREAKING CHANGE: need to update major version