### PR TITLE
feat(commitlint): add branch name linting to pre-push hook

### DIFF
--- a/.elsikora/setup-wizard.config.js
+++ b/.elsikora/setup-wizard.config.js
@@ -7,7 +7,7 @@ export default {
 		provider: "GitHub",
 	},
 	commitlint: {
-		isEnabled: false,
+		isEnabled: true,
 	},
 	eslint: {
 		isEnabled: false,

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+echo '⌛️⌛️⌛️ Running branch name linter...'
+npx @elsikora/git-branch-lint

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -86,7 +86,6 @@ export default {
 	rules: {
 		"body-full-stop": [2, "always", "."],
 		"body-leading-blank": [2, "always"],
-		"body-max-length": [0, "always", 1000],
 		"body-max-line-length": [2, "always", 100],
 		"footer-leading-blank": [2, "always"],
 		"footer-max-line-length": [2, "always", 100],

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"author": "ElsiKora",
 	"type": "module",
 	"bin": {
-		"setup-wizard": "./bin/presentation/index.js"
+		"setup-wizard": "./bin/index.js"
 	},
 	"files": [
 		"bin"
@@ -36,7 +36,7 @@
 	},
 	"config": {
 		"commitizen": {
-			"path": "@elsikora/commitizen-plugin-commitlint-ai"
+			"path": "@commitlint/cz-commitlint"
 		}
 	},
 	"dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ export default {
 	/**
 	 * Entry point for the application.
 	 */
-	input: "src/presentation/index.ts",
+	input: "src/index.ts",
 
 	/**
 	 * Output configuration.

--- a/src/application/constant/commitlint-config-husky-pre-push-script.constant.ts
+++ b/src/application/constant/commitlint-config-husky-pre-push-script.constant.ts
@@ -1,0 +1,4 @@
+export const COMMITLINT_CONFIG_HUSKY_PRE_PUSH_SCRIPT: string = `#!/usr/bin/env sh
+echo '⌛️⌛️⌛️ Running branch name linter...'
+npx @elsikora/git-branch-lint
+`;

--- a/src/application/service/commitlint-module.service.ts
+++ b/src/application/service/commitlint-module.service.ts
@@ -11,6 +11,7 @@ import { NodeCommandService } from "../../infrastructure/service/node-command.se
 import { COMMITLINT_CONFIG_CORE_DEPENDENCIES } from "../constant/commitlint-config-core-dependencies.constant";
 import { COMMITLINT_CONFIG_FILE_NAMES } from "../constant/commitlint-config-file-names.constant";
 import { COMMITLINT_CONFIG_HUSKY_COMMIT_MSG_SCRIPT } from "../constant/commitlint-config-husky-commit-msg-script.constant";
+import { COMMITLINT_CONFIG_HUSKY_PRE_PUSH_SCRIPT } from "../constant/commitlint-config-husky-pre-push-script.constant";
 import { COMMITLINT_CONFIG } from "../constant/commitlint-config.constant";
 
 import { ConfigService } from "./config.service";
@@ -140,7 +141,7 @@ export class CommitlintModuleService implements IModuleService {
 	 * Displays a summary of the setup results.
 	 */
 	private displaySetupSummary(): void {
-		const summary: Array<string> = ["Commitlint and Commitizen configuration has been created.", "", "Generated scripts:", "- npm run commit (for commitizen)", "", "Configuration files:", "- commitlint.config.js", "- .husky/commit-msg", "", "Husky git hooks have been set up to validate your commits.", "Use 'npm run commit' to create commits using the interactive commitizen interface."];
+		const summary: Array<string> = ["Commitlint and Commitizen configuration has been created.", "", "Generated scripts:", "- npm run commit (for commitizen)", "", "Configuration files:", "- commitlint.config.js", "- .husky/commit-msg", "- .husky/pre-push", "", "Husky git hooks have been set up to validate your commits and branch names.", "Use 'npm run commit' to create commits using the interactive commitizen interface."];
 
 		this.CLI_INTERFACE_SERVICE.note("Commitlint Setup", summary.join("\n"));
 	}
@@ -161,6 +162,10 @@ export class CommitlintModuleService implements IModuleService {
 
 		if (await this.FILE_SYSTEM_SERVICE.isPathExists(".husky/commit-msg")) {
 			existingFiles.push(".husky/commit-msg");
+		}
+
+		if (await this.FILE_SYSTEM_SERVICE.isPathExists(".husky/pre-push")) {
+			existingFiles.push(".husky/pre-push");
 		}
 
 		return existingFiles;
@@ -191,7 +196,7 @@ export class CommitlintModuleService implements IModuleService {
 
 	/**
 	 * Sets up Husky git hooks.
-	 * Initializes Husky, adds prepare script, and creates commit-msg hook.
+	 * Initializes Husky, adds prepare script, and creates commit-msg and pre-push hooks.
 	 */
 	private async setupHusky(): Promise<void> {
 		// Initialize husky
@@ -200,10 +205,15 @@ export class CommitlintModuleService implements IModuleService {
 		// Add prepare script if it doesn't exist
 		await this.PACKAGE_JSON_SERVICE.addScript("prepare", "husky");
 
-		// Create commit-msg hook
 		await this.COMMAND_SERVICE.execute("mkdir -p .husky");
+
+		// Create commit-msg hook
 		await this.FILE_SYSTEM_SERVICE.writeFile(".husky/commit-msg", COMMITLINT_CONFIG_HUSKY_COMMIT_MSG_SCRIPT, "utf8");
 		await this.COMMAND_SERVICE.execute("chmod +x .husky/commit-msg");
+
+		// Create pre-push hook
+		await this.FILE_SYSTEM_SERVICE.writeFile(".husky/pre-push", COMMITLINT_CONFIG_HUSKY_PRE_PUSH_SCRIPT, "utf8");
+		await this.COMMAND_SERVICE.execute("chmod +x .husky/pre-push");
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 import { Command } from "commander";
 
-import { CommandFactory } from "../infrastructure/factory/command.factory";
-import { ClackCliInterface } from "../infrastructure/service/clack-cli-interface.service";
-import { NodeFileSystemService } from "../infrastructure/service/node-file-system.service";
-
-import { AnalyzeCommandRegistrar } from "./registrar/analyze.registrar";
-import { InitCommandRegistrar } from "./registrar/init.registrar";
+import { CommandFactory } from "./infrastructure/factory/command.factory";
+import { ClackCliInterface } from "./infrastructure/service/clack-cli-interface.service";
+import { NodeFileSystemService } from "./infrastructure/service/node-file-system.service";
+import { AnalyzeCommandRegistrar } from "./presentation/registrar/analyze.registrar";
+import { InitCommandRegistrar } from "./presentation/registrar/init.registrar";
 
 const program: Command = new Command();
 


### PR DESCRIPTION
Enhanced the commitlint configuration by adding branch name linting via a pre-push hook. This improvement ensures that branch names follow the project's conventions before pushing to remote repositories.

Additional changes:
- Enabled commitlint in setup-wizard config
- Updated bin path in package.json
- Changed commitizen path to use standard commitlint adapter
- Moved index.ts to root src directory and updated related imports
- Removed body-max-length rule from commitlint config.