### PR TITLE
ci(release): disable git hooks in workflow and switch to commitlint-ai

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Disable hooks
+      - run: git config --local core.hooksPath /dev/null
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	},
 	"config": {
 		"commitizen": {
-			"path": "@commitlint/cz-commitlint"
+			"path": "@elsikora/commitizen-plugin-commitlint-ai"
 		}
 	},
 	"dependencies": {
@@ -46,7 +46,6 @@
 	"devDependencies": {
 		"@commitlint/cli": "^19.7.1",
 		"@commitlint/config-conventional": "^19.7.1",
-		"@commitlint/cz-commitlint": "^19.6.1",
 		"@commitlint/types": "^19.5.0",
 		"@elsikora/commitizen-plugin-commitlint-ai": "^1.0.0",
 		"@elsikora/eslint-config": "^3.3.4",

--- a/src/domain/constant/ci-config.constant.ts
+++ b/src/domain/constant/ci-config.constant.ts
@@ -169,6 +169,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Disable hooks
+  		run: git config --local core.hooksPath /dev/null
+  
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -234,6 +237,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Disable hooks
+  		run: git config --local core.hooksPath /dev/null
+  		
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
- Added step to disable git hooks in release workflow to prevent issues during CI execution.
- Replaced @commitlint/cz-commitlint with @elsikora/commitizen-plugin-commitlint-ai for improved commit message generation.
- Updated CI config constants to include the hook disabling step in templates.