### PR TITLE
fix(ci): correct indentation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Disable hooks
-      - run: git config --local core.hooksPath /dev/null
+        run: git config --local core.hooksPath /dev/null
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixed incorrect indentation in the release.yml GitHub workflow file. The run command was incorrectly prefixed with a dash, which prevented the 'Disable hooks' step from executing properly.