### PR TITLE
ci(workflows): improve husky hook skipping in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Disable hooks
-        run: git config --local core.hooksPath /dev/null
+      - name: Disable Husky hooks
+        run: echo "HUSKY_SKIP_HOOKS=1" >> $GITHUB_ENV
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Changed the method for disabling Husky hooks in the release workflow. Instead of modifying the git hooks path, we now set the HUSKY_SKIP_HOOKS environment variable, which is a more targeted approach to skip only Husky hooks while preserving other git functionality.