### PR TITLE
chore(commitizen): update commitizen path to use ai-powered plugin

### DIFF
--- a/src/application/service/commitlint-module.service.ts
+++ b/src/application/service/commitlint-module.service.ts
@@ -226,7 +226,7 @@ export class CommitlintModuleService implements IModuleService {
 			packageJson.config = {};
 		}
 		packageJson.config.commitizen = {
-			path: "@commitlint/cz-commitlint",
+			path: "@elsikora/commitizen-plugin-commitlint-ai",
 		};
 
 		await this.PACKAGE_JSON_SERVICE.set(packageJson);


### PR DESCRIPTION
Changed the commitizen path in package.json configuration from '@commitlint/cz-commitlint' to '@elsikora/commitizen-plugin-commitlint-ai'. This will enable AI-powered commit message generation.