### PR TITLE
fix(husky): remove husky.sh import from pre-commit script

### DIFF
--- a/src/application/constant/lint-staged-config-husky-pre-commit-script.constant.ts
+++ b/src/application/constant/lint-staged-config-husky-pre-commit-script.constant.ts
@@ -1,5 +1,4 @@
 export const LINT_STAGED_CONFIG_HUSKY_PRE_COMMIT_SCRIPT: string = `#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 echo '⌛️⌛️⌛️ Running pre-commiting checks...'
 npx lint-staged


### PR DESCRIPTION
Removed unnecessary husky.sh import from the lint-staged pre-commit script constant. This line was causing issues when the script was executed in some environments.