### PR TITLE
build(test): update e2e test script to include build step and typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"prepare": "husky",
 		"release": "semantic-release",
 		"test:all": "npm run test:unit && npm run test:e2e",
-		"test:e2e": "vitest --config vitest.config.e2e.ts",
+		"test:e2e": "npm run build && vitest --config vitest.config.e2e.ts --typecheck.tsconfig tsconfig.json",
 		"test:unit": "vitest run test/unit --config vitest.config.unit.ts"
 	},
 	"config": {


### PR DESCRIPTION
Enhanced the e2e test script to run the build command before tests and enabled TypeScript type checking during test execution. This ensures that all tests run against the latest build and validates TypeScript types.