### PR TITLE
build(lint-staged): exclude changelog files from eslint checks

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,7 +3,7 @@ export default {
 		const commands = [];
 		commands.push("prettier --write --ignore-unknown");
 
-		const filteredFiles = files.filter((file) => !file.includes("test/") && !file.includes("vitest"));
+		const filteredFiles = files.filter((file) => !file.includes("test/") && !file.includes("vitest") && !file.includes("CHANGELOG"));
 
 		const eslintFiles = filteredFiles.filter((file) => {
 			const validExtensions = ["js", "jsx", "mjs", "cjs", "ts", "tsx", "json", "jsonc", "yml", "yaml", "md", "mdx"];


### PR DESCRIPTION
Updated lint-staged configuration to exclude CHANGELOG files from linting process to prevent unnecessary formatting of auto-generated changelog content.