### PR TITLE
fix(config): update default config file path to use js extension

### DIFF
--- a/src/infrastructure/service/cosmi-config-config.service.ts
+++ b/src/infrastructure/service/cosmi-config-config.service.ts
@@ -165,7 +165,7 @@ export class CosmicConfigService implements IConfigService {
 		try {
 			const result: { config: IConfig; filepath: string; isEmpty?: boolean } | null = await this.EXPLORER.search();
 
-			const filePath: string = result?.filepath ?? `.${CONFIG_MODULE_NAME}rc.json`;
+			const filePath: string = result?.filepath ?? `${CONFIG_FILE_DIRECTORY}/${CONFIG_MODULE_NAME}.config.js`;
 
 			await this.writeFile(filePath, config);
 


### PR DESCRIPTION
Changed the default configuration file path to use a more standardized location and format. The default path now uses a .config.js extension instead of .rc.json format, which provides better support for complex configuration options.