### PR TITLE
feat(lint-staged): add typescript type checking to pre-commit hooks

### DIFF
--- a/src/application/constant/eslint/core-dependencies.constant.ts
+++ b/src/application/constant/eslint/core-dependencies.constant.ts
@@ -1,1 +1,1 @@
-export const ESLINT_CONFIG_CORE_DEPENDENCIES: Array<string> = ["@elsikora/eslint-config", "eslint"];
+export const ESLINT_CONFIG_CORE_DEPENDENCIES: Array<string> = ["@elsikora/eslint-config", "eslint", "tsc-files"];

--- a/src/application/constant/lint-staged/config.constant.ts
+++ b/src/application/constant/lint-staged/config.constant.ts
@@ -39,9 +39,15 @@ export const LINT_STAGED_CONFIG: {
           return hasValidExtension && !hasNoExtension;
         });
 
+		const tsFiles = files.filter((file) => /\\.(ts|tsx)$/.test(file));
+
         if (eslintFiles.length > 0) {
           commands.push(\`eslint --fix --max-warnings=0 --no-warn-ignored \${eslintFiles.join(" ")}\`);
-        }`);
+        }
+		
+		if (tsFiles.length > 0) {
+   		  commands.push(\`tsc-files --noEmit --skipLibCheck --incremental false global.d.ts \${tsFiles.join(" ")}\`);
+  		}`);
 		}
 
 		if (features.includes(ELintStagedFeature.STYLELINT)) {


### PR DESCRIPTION
Added tsc-files dependency to eslint core dependencies and integrated TypeScript type checking into lint-staged configuration.

The lint-staged config now runs type checking on TypeScript files (.ts, .tsx) during pre-commit hooks using tsc-files with --noEmit flag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `tsc-files` and updates lint-staged to type-check staged `.ts/.tsx` files alongside ESLint.
> 
> - **Lint-staged**:
>   - Detects staged `ts/tsx` files and runs `tsc-files --noEmit --skipLibCheck --incremental false global.d.ts <files>` in addition to ESLint.
> - **Dependencies**:
>   - Adds `tsc-files` to `ESLINT_CONFIG_CORE_DEPENDENCIES`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8efca8f0605f69ce236985f8221b36a6e99cde7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->